### PR TITLE
Add estimation period to planning advisor flow

### DIFF
--- a/apps/agni-server/src/core/interactions/analystic/suggestPlanningSaveGoalUseCase.ts
+++ b/apps/agni-server/src/core/interactions/analystic/suggestPlanningSaveGoalUseCase.ts
@@ -3,7 +3,6 @@ import { SavingRepository } from "@core/repositories/savingRepository"
 import { AccountRepository } from "@core/repositories/accountRepository"
 import IAgentScoringGoal, { InputSaveGoalAgent } from "@core/agents/agentGoalScoring"
 import IAgentPlanningAdvisor, { GoalPlanningAdvisor } from "@core/agents/agentPlanningAdvisor"
-import { MomentDateService } from "@core/domains/entities/libs"
 import { AccountType, Period } from "@core/domains/constants"
 import { GetEstimationLeftAmoutDto, RequestEstimationLeftAmount } from "./estimationleftAmount"
 
@@ -20,9 +19,11 @@ export type SuggestGoalPlanning = {
 }
 
 export type RequestSuggestPlanningSaveGoal = {
+    estimationPeriodStart: Date,
+    estimationPeriodEnd: Date
     comment: string,
     wishSpends?: SuggestPlanningWishSpend[]
-    wishGoals: { goalId: string, amountSuggest: number}[]
+    wishGoals?: { goalId: string, amountSuggest: number}[]
 }
 
 export type GetAllSuggestPlanningDto = {
@@ -55,8 +56,8 @@ export class SuggestPlanningSaveGoalUseCase implements IUsecase<RequestSuggestPl
 
     async execute(request: RequestSuggestPlanningSaveGoal): Promise<GetAllSuggestPlanningDto> {
         
-        const workingStartDate = MomentDateService.getToday();
-        const workingEndDate = MomentDateService.getUTCDateAddition(workingStartDate, Period.WEEK, 2);
+        const workingStartDate = request.estimationPeriodStart;
+        const workingEndDate = request.estimationPeriodEnd;
 
         const accounts = await this.accountRepo.getAll();
 
@@ -122,7 +123,7 @@ export class SuggestPlanningSaveGoalUseCase implements IUsecase<RequestSuggestPl
 
         const resultPlannings = await this.planningAdvisor.process({
             comment: request.comment,
-            whishGoalTarget: request.wishGoals.map(i => ({ goalId: i.goalId, amount: i.amountSuggest})),
+            whishGoalTarget: request.wishGoals?.map(i => ({ goalId: i.goalId, amount: i.amountSuggest})) || [],
             amountToAllocate: estimationAmountToAllocate,
             currentAmountInInvestissment: currentInvestissment,
             currentAmountInSaving: currentSaving,

--- a/apps/agni-server/src/routes/analytics.ts
+++ b/apps/agni-server/src/routes/analytics.ts
@@ -7,8 +7,8 @@ import container from 'src/di_contenair';
 const router = Router();
 
 router.get('/v1/analytics/estimation-left-amount', 
-    query('startDate').isDate().notEmpty(),
-    query('endDate').isDate().notEmpty()
+    query('startDate').notEmpty().isISO8601().toDate(),
+    query('endDate').notEmpty().isISO8601().toDate()
     , async (req, res) => {
     try {
         const result = validationResult(req);
@@ -29,12 +29,14 @@ router.get('/v1/analytics/estimation-left-amount',
 
 router.post('/v1/analytics/save-goal-planning', 
     body('comment').isString().optional(),
+    body('estimationPeriodStart').notEmpty().isISO8601().toDate(),
+    body('estimationPeriodEnd').notEmpty().isISO8601().toDate(),
     body('wishGoals').isArray().optional(),
-    body('wishGoals.*.goalId').isString(),
-    body('wishGoals.*.amountSuggest').isNumeric(),
+    body('wishGoals.*.goalId').exists().isString(),
+    body('wishGoals.*.amountSuggest').exists().isNumeric(),
     body('wishSpends').isArray().optional(),
-    body('wishSpends.*.amount').isNumeric(),
-    body('wishSpends.*.description').isString(),
+    body('wishSpends.*.amount').exists().isNumeric(),
+    body('wishSpends.*.description').exists().isString(),
     async (req,  res) => {
         try {
             const result = validationResult(req);

--- a/apps/agni-web/composables/agents/usePlanningAdvisorAgent.ts
+++ b/apps/agni-web/composables/agents/usePlanningAdvisorAgent.ts
@@ -23,6 +23,7 @@ export default function usePlanningAdvisorAgent(request: AgentAdvisorRequest): U
 }
 
 export async function fetchPlanningAdvisorAgent(request: AgentAdvisorRequest): Promise<PlanningAgentAdvisorType>{
+    console.log(request)
     const response = await $fetch<AgentPlanningAdvisorResponse>('/api/agents/planningAdvisor', {
         method: 'POST',
         body: request 

--- a/apps/agni-web/types/api/agent.d.ts
+++ b/apps/agni-web/types/api/agent.d.ts
@@ -1,5 +1,7 @@
 export type AgentAdvisorRequest = {
     comment: string
+    estimationPeriodStart: string
+    estimationPeriodEnd: string
     wishSpends: { amount: number, description: string } []
     wishGoals: { goalId: string, amountSuggest: number} []
 }

--- a/apps/ia-agent/core/dto.py
+++ b/apps/ia-agent/core/dto.py
@@ -29,7 +29,7 @@ class GoalToPlanDto(BaseModel):
     wish_due_date: Optional[str] = None 
 
 class WishGoalToTargetDto(BaseModel):
-    goal_uuid: float
+    goal_uuid: str
     amount: int
 
 class AgentPlanningAdivsorInput(BaseModel):


### PR DESCRIPTION
Introduces estimationPeriodStart and estimationPeriodEnd fields to the planning advisor request and UI, allowing users to specify a date range for goal planning. Updates backend validation, DTOs, and frontend components to support these new fields and improves input handling for wish goals and spends.