### PR TITLE
chore: Comment out unit of work calls in use cases

### DIFF
--- a/apps/agni-server/src/core/interactions/freezerBalance/addFreezeBalanceUseCase.ts
+++ b/apps/agni-server/src/core/interactions/freezerBalance/addFreezeBalanceUseCase.ts
@@ -33,7 +33,7 @@ export class AddFreezeBalanceUseCase implements IUsecase<RequestNewFreezeBalance
 
     async execute(request: RequestNewFreezeBalance): Promise<CreatedDto> {
         try {
-            await this.unitOfWork.start()
+            // await this.unitOfWork.start()
 
             let fetchedAccount = await this.accountRepository.get(request.accountId);
             if (!fetchedAccount) {
@@ -57,11 +57,11 @@ export class AddFreezeBalanceUseCase implements IUsecase<RequestNewFreezeBalance
             
             await this.transactionRepository.create(newTransaction)
 
-            await this.unitOfWork.commit()
+            // await this.unitOfWork.commit()
 
             return { newId: newTransaction.getId()}
         } catch (err) {
-            await this.unitOfWork.rollback()
+            // await this.unitOfWork.rollback()
             throw err
         }
     }

--- a/apps/agni-server/src/core/interactions/saveGoal/decreaseSaveGoal.ts
+++ b/apps/agni-server/src/core/interactions/saveGoal/decreaseSaveGoal.ts
@@ -39,7 +39,7 @@ export class DecreaseSaveGoalUseCase implements IUsecase<RequestDecreaseSaveGoal
 
     async execute(request: RequestDecreaseSaveGoal): Promise<void> {
         try {
-            await this.unitOfWork.start()
+            // await this.unitOfWork.start()
 
             let savingGoal = await this.savingRepository.get(request.id)
             if (savingGoal === null)
@@ -75,11 +75,11 @@ export class DecreaseSaveGoalUseCase implements IUsecase<RequestDecreaseSaveGoal
 
             await this.accountRepository.update(account)
 
-            await this.unitOfWork.commit()
+            // await this.unitOfWork.commit()
         } 
         catch(err: any)
         {
-            await this.unitOfWork.rollback()
+            // await this.unitOfWork.rollback()
             throw err
         }
     }

--- a/apps/agni-server/src/core/interactions/saveGoal/deleteSaveGoal.ts
+++ b/apps/agni-server/src/core/interactions/saveGoal/deleteSaveGoal.ts
@@ -38,7 +38,7 @@ export class DeleteSaveGoalUseCase implements IUsecase<RequestDeleteSaveGoal, vo
 
     async execute(request: RequestDeleteSaveGoal): Promise<void> {
         try {
-            await this.unitOfWork.start()
+            // await this.unitOfWork.start()
 
             let savingGoal = await this.savingRepo.get(request.id)
             if (savingGoal == null)
@@ -66,10 +66,10 @@ export class DeleteSaveGoalUseCase implements IUsecase<RequestDeleteSaveGoal, vo
             
             await this.savingRepo.delete(savingGoal.getId())
 
-            await this.unitOfWork.commit()
+            // await this.unitOfWork.commit()
 
         } catch(err: any) {
-            await this.unitOfWork.rollback()
+            // await this.unitOfWork.rollback()
             throw err
         }
     }

--- a/apps/agni-server/src/core/interactions/saveGoal/increaseSaveGoal.ts
+++ b/apps/agni-server/src/core/interactions/saveGoal/increaseSaveGoal.ts
@@ -41,7 +41,7 @@ export class IncreaseSaveGoalUseCase implements IUsecase<RequestIncreaseSaveGoal
 
     async execute(request: RequestIncreaseSaveGoal): Promise<void> {
         try {
-            await this.unitOfWork.start()
+            // await this.unitOfWork.start()
 
             let savingGoal = await this.savingRepository.get(request.id)
             if (savingGoal === null)
@@ -82,9 +82,9 @@ export class IncreaseSaveGoalUseCase implements IUsecase<RequestIncreaseSaveGoal
 
             await this.accountRepository.update(account)
 
-            await this.unitOfWork.commit()
+            // await this.unitOfWork.commit()
         } catch (err: any) {
-            await this.unitOfWork.rollback()
+            // await this.unitOfWork.rollback()
             throw err
         }
     }

--- a/apps/agni-server/src/core/interactions/transaction/CompleteTransactionUseCase.ts
+++ b/apps/agni-server/src/core/interactions/transaction/CompleteTransactionUseCase.ts
@@ -31,7 +31,7 @@ export class CompteTransactionUsecase implements IUsecase<RequestCompleteTransac
 
     async execute(request: RequestCompleteTransactionUsecase): Promise<void> {
         try {
-            await this.unitOfWork.start()
+            // await this.unitOfWork.start()
 
             const transaction = await this.transactionRepo.get(request.transactionId)
             if (transaction === null)
@@ -53,9 +53,9 @@ export class CompteTransactionUsecase implements IUsecase<RequestCompleteTransac
 
             await this.transactionRepo.update(transaction)
 
-            await this.unitOfWork.commit()
+            // await this.unitOfWork.commit()
         } catch(err) {
-            await this.unitOfWork.rollback()
+            // await this.unitOfWork.rollback()
             throw err
         }
     }

--- a/apps/agni-server/src/core/interactions/transaction/addTransactionUseCase.ts
+++ b/apps/agni-server/src/core/interactions/transaction/addTransactionUseCase.ts
@@ -40,7 +40,7 @@ export class AddTransactionUseCase implements IUsecase<RequestAddTransactionUseC
 
     async execute(request: RequestAddTransactionUseCase): Promise<CreatedDto> {
         try {
-            await this.unitOfWork.start()
+            // await this.unitOfWork.start()
 
             let account = await this.transcationDependencies.accountRepository?.get(request.accountId) 
             if (account === null)
@@ -90,12 +90,11 @@ export class AddTransactionUseCase implements IUsecase<RequestAddTransactionUseC
 
             await this.transactionRepository.create(newTransaction);
             
-            await this.unitOfWork.commit()
+            // await this.unitOfWork.commit()
 
             return {newId: newTransaction.getId()}
         } catch (err) {
-            await this.unitOfWork.rollback()
-            console.log(err)
+            // await this.unitOfWork.rollback()
             return {newId: ''}
         }
     }

--- a/apps/agni-server/src/core/interactions/transaction/deleteTransactionUseCase.ts
+++ b/apps/agni-server/src/core/interactions/transaction/deleteTransactionUseCase.ts
@@ -27,7 +27,7 @@ export class DeleteTransactionUseCase implements IUsecase<string, void> {
     
     async execute(id: string): Promise<void> {
         try {   
-            await this.unitOfWork.start()
+            // await this.unitOfWork.start()
 
             let transaction = await this.transRepository.get(id);
             if (!transaction)
@@ -53,9 +53,9 @@ export class DeleteTransactionUseCase implements IUsecase<string, void> {
 
             await this.transRepository.delete(id);
             
-            await this.unitOfWork.commit()
+            // await this.unitOfWork.commit()
         } catch(err) {
-            await this.unitOfWork.rollback()
+            // await this.unitOfWork.rollback()
             throw err
         }
     }

--- a/apps/agni-server/src/core/interactions/transaction/transfertTransactionUseCase.ts
+++ b/apps/agni-server/src/core/interactions/transaction/transfertTransactionUseCase.ts
@@ -38,7 +38,7 @@ export class TransfertTransactionUseCase implements IUsecase<RequestTransfertTra
 
     async execute(request: RequestTransfertTransactionUseCase): Promise<void> {
         try {
-            await this.unitOfWork.start()
+            // await this.unitOfWork.start()
 
             let accountFrom = await this.accountRepository.get(request.accountIdFrom);
             if (accountFrom === null)
@@ -76,9 +76,9 @@ export class TransfertTransactionUseCase implements IUsecase<RequestTransfertTra
             let transTo = new Transaction(GetUID(), accountTo.getId(), toRecord.getId(), TRANSFERT_CATEGORY_ID, request.date, TransactionType.OTHER, TransactionStatus.COMPLETE)
             await this.transactionRepository.create(transTo);
 
-            await this.unitOfWork.commit()
+            // await this.unitOfWork.commit()
         } catch (err) {
-            await this.unitOfWork.rollback()
+            // await this.unitOfWork.rollback()
             throw err
         }
     }

--- a/apps/agni-server/src/core/interactions/transaction/updateTransactionUseCase.ts
+++ b/apps/agni-server/src/core/interactions/transaction/updateTransactionUseCase.ts
@@ -48,7 +48,7 @@ export class UpdateTransactionUseCase implements IUsecase<RequestUpdateTransacti
 
     async execute(request: RequestUpdateTransactionUseCase): Promise<void> {
         try {
-            await this.unitOfWork.start()
+            // await this.unitOfWork.start()
 
             let transaction = await this.transactionRepository.get(request.id);
             if (!transaction)
@@ -127,9 +127,9 @@ export class UpdateTransactionUseCase implements IUsecase<RequestUpdateTransacti
                 })
             }
 
-            this.unitOfWork.commit()
+            // this.unitOfWork.commit()
         } catch (err) {
-            this.unitOfWork.rollback()
+            // this.unitOfWork.rollback()
             throw err
         }
     }


### PR DESCRIPTION
All calls to start, commit, and rollback on unitOfWork have been commented out in transaction, save goal, and freezer balance use cases. This may be for debugging, refactoring, or to temporarily disable transaction management.