### PR TITLE
Fix account freeze balance filtering and UI formatting

### DIFF
--- a/apps/agni-server/src/core/interactions/account/getAccountWithDetailUseCase.ts
+++ b/apps/agni-server/src/core/interactions/account/getAccountWithDetailUseCase.ts
@@ -38,6 +38,7 @@ export class GetAccountDetailUseCase implements IUsecase<string, GetAccountDetai
 
         const transactionExtendFilter = new TransactionFilter()
         transactionExtendFilter.isFreeze = true
+        transactionExtendFilter.accounts = [account.getId()]
         const freezeTransacions = await this.transactionRepo.getAll({ offset: 0, limit: 1, queryAll: true }, transactionExtendFilter)
         const records = await this.recordRepo.getManyByIds(freezeTransacions.items.map(i => i.getRecordRef()))
         const freezeAmount = records.reduce((acc, curr) => acc += curr.getMoney().getAmount(), 0)

--- a/apps/agni-server/src/core/interactions/account/getAllAccountWithDetailUseCase.ts
+++ b/apps/agni-server/src/core/interactions/account/getAllAccountWithDetailUseCase.ts
@@ -41,6 +41,7 @@ export class GetAllAccountWithDetailUseCase implements IUsecase<QueryFilter, Lis
         let accountsDisplay: GetAllAccountWithDetailDto[] = [];
         for (let account of accounts.items) {
             const transactionExtendFilter = new TransactionFilter()
+            transactionExtendFilter.accounts = [account.getId()]
             transactionExtendFilter.isFreeze = true
             const freezeTransacions = await this.transactionRepo.getAll({ offset: 0, limit: 1, queryAll: true }, transactionExtendFilter)
             const records = await this.recordRepo.getManyByIds(freezeTransacions.items.map(i => i.getRecordRef()))

--- a/apps/agni-server/src/core/interactions/transaction/getBalanceByUseCase.ts
+++ b/apps/agni-server/src/core/interactions/transaction/getBalanceByUseCase.ts
@@ -71,7 +71,6 @@ export class GetBalanceByUseCase implements IUsecase<RequestGetPagination, numbe
         extendTransactionFilter.types = types
 
         const transactions = await this.transactionRepository.getAll(filter, extendTransactionFilter);
-        console.log(transactions.total)
 
         let records = await this.recordRepository
             .getManyByIds(transactions.items.filter(i => i.getStatus() == TransactionStatus.COMPLETE)

--- a/apps/agni-web/components/AmountTitle/index.vue
+++ b/apps/agni-web/components/AmountTitle/index.vue
@@ -12,6 +12,7 @@ const amountValue = computed<{integer: string, decimal: string}>(() => {
 }) 
 
 watch([() => amount], () => {
+    amountRounded.value = ""
     amountRounded.value = amount.toFixed(2) 
 })
 

--- a/apps/agni-web/components/CardResumeAccount/index.vue
+++ b/apps/agni-web/components/CardResumeAccount/index.vue
@@ -41,8 +41,8 @@ const props = defineProps({
                         :sign="'$'"
                     />
                     <div class="text-xs text-gray-300">
-                        <p>Freezed Balance: ${{ freezedBalance }}</p>
-                        <p>Locked Balance: ${{ lockedBalance }}</p>
+                        <p>Freezed Balance: ${{ freezedBalance?.toFixed(2) }}</p>
+                        <p>Locked Balance: ${{ lockedBalance?.toFixed(2) }}</p>
                     </div>
                 </div>
 

--- a/apps/agni-web/pages/wallets/index.vue
+++ b/apps/agni-web/pages/wallets/index.vue
@@ -327,8 +327,8 @@ const onUpateAccount = async (payload: string) => {
                         :sign="'$'"
                     />
                     <div class="text-xs text-gray-300">
-                        <p>Freezed Balance: ${{ getAccount(selectedAccountId)?.freezedBalance ?? 0 }}</p>
-                        <p>Locked Balance: ${{ getAccount(selectedAccountId)?.lockedBalance ?? 0 }}</p>
+                        <p>Freezed Balance: ${{ getAccount(selectedAccountId)?.freezedBalance.toFixed(2) ?? 0 }}</p>
+                        <p>Locked Balance: ${{ getAccount(selectedAccountId)?.lockedBalance.toFixed(2) ?? 0 }}</p>
                     </div>
                 </div>
 


### PR DESCRIPTION
Server: Ensure freeze transaction queries are filtered by account ID in account detail use cases. Remove debug log from getBalanceByUseCase. Web: Reset amountRounded on amount change and format freezed/locked balances to two decimals in CardResumeAccount and wallets page.