### PR TITLE
Refactor account migration to remove domain dependencies

### DIFF
--- a/apps/agni-server/migrations/20251107022401_addNewFeatCurrencyAndHolding.ts
+++ b/apps/agni-server/migrations/20251107022401_addNewFeatCurrencyAndHolding.ts
@@ -1,6 +1,3 @@
-import { AccountType, ContributionAccountType, DOLLAR_CURRENT_ID, ManagementAccountType, mapperTypeAccount } from "@core/domains/constants";
-import { BrockageAccountDetail } from "../../agni-server/src/core/domains/valueObjects/brockageAccount";
-import { CreditCardAccountDetail } from "../../agni-server/src/core/domains/valueObjects/creditCardAccount";
 import type { Knex } from "knex";
 
 
@@ -8,23 +5,25 @@ export async function up(knex: Knex): Promise<void> {
 
     if (!await knex.schema.hasColumn('accounts', 'currency_id')) {
         await knex.schema.alterTable('accounts', function(table) {
-            table.uuid('currency_id').defaultTo(DOLLAR_CURRENT_ID)
+            table.uuid('currency_id').defaultTo("4be50a1e-71b9-4941-b00a-ca8409949736")
             table.json('detail').nullable()
             table.dropColumn('credit_limit')
         })
 
         const results = await knex('accounts')
         for(let result of results) {
-            const type = mapperTypeAccount(result['type'])
             let detail = null 
-            switch(type) {
-                case AccountType.CREDIT_CARD:
-                    const cc = new CreditCardAccountDetail(0)
-                    detail = cc.toJson()
+            switch(result['type']) {
+                case "CreditCard":
+                    detail = JSON.stringify({
+                        credit_limit: 0
+                    })
                     break
-                case AccountType.BROKING:
-                    const broke = new BrockageAccountDetail(ManagementAccountType.MANAGED, ContributionAccountType.UNREGISTERED)
-                    detail = broke.toJson()
+                case "Broking":
+                    detail = JSON.stringify({
+                        management_type: "Managed", 
+                        contribution_account: "Unregistered" 
+                    })
                     break 
             } 
  


### PR DESCRIPTION
Removed imports from domain constants and value objects in the migration. Replaced usage of domain types and classes with direct string values and JSON objects for account details, simplifying the migration and reducing coupling to domain logic.