### PR TITLE
Ensure req.params.id is typed as string in route handlers

### DIFF
--- a/apps/agni-server/src/routes/accounts.ts
+++ b/apps/agni-server/src/routes/accounts.ts
@@ -53,7 +53,7 @@ router.put('/v1/accounts/:id',
             }
 
             const data: RequestUpdateAccountUseCase = matchedData(req);
-            data.id = req.params.id;
+            data.id = req.params.id as string;
             await container.accountUseCase?.updateAccount.execute(data);
 
             res.sendStatus(200);
@@ -66,7 +66,8 @@ router.put('/v1/accounts/:id',
 router.get('/v1/accounts/:id', 
     async (req: Request, res: Response) => {
     try {
-        const account = await container.accountUseCase?.getAccount.execute(req.params.id)
+        const id = req.params.id as string
+        const account = await container.accountUseCase?.getAccount.execute(id)
         res.status(200).json(account)
     } catch(err) {
         res.status(400).send({ errors: [err] });
@@ -77,7 +78,8 @@ router.get('/v1/accounts/:id',
 router.get('/v1/accounts-with-detail/:id', 
     async (req: Request, res: Response) => {
     try {
-        const account = await container.accountUseCase?.getAccountWithDetail.execute(req.params.id)
+        const id = req.params.id as string
+        const account = await container.accountUseCase?.getAccountWithDetail.execute(id)
         res.status(200).json(account)
         return 
     } catch(err) {

--- a/apps/agni-server/src/routes/budgets.ts
+++ b/apps/agni-server/src/routes/budgets.ts
@@ -47,7 +47,7 @@ router.put('/v1/budgets/:id',
             const result = validationResult(req);
             if (result.isEmpty()) {
                 const data: RequestUpdateBudget = matchedData(req);
-                data.id = req.params.id;
+                data.id = req.params.id as string;
                 await container.budgetUseCase?.updateBudget.execute(data);
 
                 res.sendStatus(200);

--- a/apps/agni-server/src/routes/categories.ts
+++ b/apps/agni-server/src/routes/categories.ts
@@ -38,7 +38,7 @@ router.put('/v1/categories/:id',
             const result = validationResult(req);
             if (result.isEmpty()) {
                 const data: RequestUpdateCategoryUseCase = matchedData(req);
-                data.id = req.params.id;
+                data.id = req.params.id as string;
                 await container.categoryUseCase?.updateCategory.execute(data);
 
                 res.sendStatus(200);

--- a/apps/agni-server/src/routes/currency.ts
+++ b/apps/agni-server/src/routes/currency.ts
@@ -44,7 +44,7 @@ router.put(
         const result = validationResult(req);
         if (result.isEmpty()) {
             const data: RequestUpdateCurrency = matchedData(req);
-            data.id = req.params.id
+            data.id = req.params.id as string
             var created = await container.currencyUseCase?.updateCurrency.execute(data);
 
             res.status(200).json(created)
@@ -59,7 +59,8 @@ router.put(
 
 router.get('/v1/currencies/:id', async (req: Request, res: Response) => {
     try {
-        var result = await container.currencyUseCase?.getCurrency.execute(req.params.id);
+        const id = req.params.id as string
+        var result = await container.currencyUseCase?.getCurrency.execute(id);
 
         res.status(200).json(result)
     } catch(err) {

--- a/apps/agni-server/src/routes/holding.ts
+++ b/apps/agni-server/src/routes/holding.ts
@@ -52,7 +52,7 @@ router.put(
         const result = validationResult(req);
         if (result.isEmpty()) {
             const data: RequestUpdateHoldingDto = matchedData(req);
-            data.id = req.params.id
+            data.id = req.params.id as string
             var created = await container.holdingUseCase?.updateHolding.execute(data);
 
             res.status(200).json(created)
@@ -132,7 +132,7 @@ router.put(
         const result = validationResult(req);
         if (result.isEmpty()) {
             const data: RequestUpdateHoldingTransactionDto = matchedData(req);
-            data.id = req.params.id
+            data.id = req.params.id as string
 
             var results = await container.holdingUseCase?.updateHoldingTransaction.execute(data);
 
@@ -151,7 +151,8 @@ router.get(
     '/v1/holding-transactions/:id', 
     async (req: Request, res: Response) => {
     try {
-        const result = await container.holdingUseCase?.getHoldingTransaction.execute(req.params.id)
+        const id = req.params.id as string
+        const result = await container.holdingUseCase?.getHoldingTransaction.execute(id)
         
         res.status(200).json(result)
     } catch(err) {
@@ -191,7 +192,8 @@ router.delete(
     '/v1/holdings/:id', 
     async (req: Request, res: Response) => {
     try {
-        const result = await container.holdingUseCase?.deleteHolding.execute(req.params.id)
+        const id = req.params.id as string
+        const result = await container.holdingUseCase?.deleteHolding.execute(id)
         
         res.status(200).json(result)
     } catch(err) {
@@ -203,7 +205,8 @@ router.delete(
     '/v1/holding-transactions/:id', 
     async (req: Request, res: Response) => {
     try {
-        const result = await container.holdingUseCase?.deleteHoldingTransaction.execute(req.params.id)
+        const id = req.params.id as string
+        const result = await container.holdingUseCase?.deleteHoldingTransaction.execute(id)
         
         res.status(200).json(result)
     } catch(err) {

--- a/apps/agni-server/src/routes/patrimony.ts
+++ b/apps/agni-server/src/routes/patrimony.ts
@@ -45,7 +45,7 @@ router.put('/v1/patrimonies/:id',
             const result = validationResult(req);
             if (result.isEmpty()) {
                 const data: RequestUpdatePatrimony = matchedData(req);
-                data.patrimonyId = req.params.id
+                data.patrimonyId = req.params.id as string
                 await container.patrimonyUseCase?.updatePatrimony.execute(data);
 
                 res.sendStatus(200)
@@ -67,7 +67,7 @@ router.get('/v1/patrimonies/:id',
     async (req:Request, res: Response) => {
         try {
             const data: RequestGetPatrimony = matchedData(req);
-            data.patrimonyId = req.params.id
+            data.patrimonyId = req.params.id as string
             const patrimony = await container.patrimonyUseCase?.getPatrimony.execute(data)
 
             res.status(200).json(patrimony)
@@ -117,7 +117,7 @@ router.post('/v1/patrimonies/:id/add-snapshot',
             const result = validationResult(req);
             if (result.isEmpty()) {
                 const data: RequestAddSnapshotPatrimony = matchedData(req);
-                data.patrimonyId = req.params.id
+                data.patrimonyId = req.params.id as string
                 var created = await container.patrimonyUseCase?.addSnapshotPatrimony.execute(data);
 
                 res.status(200).json(created)
@@ -143,7 +143,7 @@ router.get('/v1/patrimonies/:id/snapshots',
             const result = validationResult(req);
             if (result.isEmpty()) {
                 const data: RequestAllSnapshotPatrimony = matchedData(req);
-                data.patrimonyId = req.params.id
+                data.patrimonyId = req.params.id as string
                 var snapshots = await container.patrimonyUseCase?.getSnapshotPatrimony.execute(data);
 
                 res.status(200).json(snapshots)
@@ -180,8 +180,8 @@ router.put('/v1/patrimonies/:id/update-snapshot/:id_snapshot',
             const result = validationResult(req);
             if (result.isEmpty()) {
                 const data: RequestUpdateSnapshotPatrimony = matchedData(req);
-                data.patrimonyId = req.params.id
-                data.snapshotId = req.params.id_snapshot
+                data.patrimonyId = req.params.id as string
+                data.snapshotId = req.params.id_snapshot as string
                 await container.patrimonyUseCase?.updateSnapshotPatrimony.execute(data);
 
                 res.sendStatus(200)

--- a/apps/agni-server/src/routes/savingGoals.ts
+++ b/apps/agni-server/src/routes/savingGoals.ts
@@ -52,7 +52,7 @@ router.put('/v1/save-goals/:id',
             if (result.isEmpty()) {
                 const data: RequestUpdateSaveGoalUseCase = matchedData(req); 
                 console.log(data)
-                data.id = req.params.id;
+                data.id = req.params.id as string;
                 await container.saveGoalUseCase?.updateSaveGoal.execute(data);
 
                 res.sendStatus(200);
@@ -103,7 +103,7 @@ router.delete('/v1/save-goals/:id', body('accountDepositId').isString().notEmpty
         const result = validationResult(req);
         if (result.isEmpty()) {
             const data: RequestDeleteSaveGoal = matchedData(req);
-            data.id = req.params.id;
+            data.id = req.params.id as string;
             await container.saveGoalUseCase?.deleteSaveGoal.execute(data);
             
             res.sendStatus(200);
@@ -124,7 +124,7 @@ router.patch('/v1/save-goals/:id/increase-balance',
             const result = validationResult(req);
             if (result.isEmpty()) {
                 const data: RequestIncreaseSaveGoal = matchedData(req);
-                data.id = req.params.id
+                data.id = req.params.id as string
                 await container.saveGoalUseCase?.increaseSaveGoal.execute(data);
 
                 res.sendStatus(200);
@@ -146,7 +146,7 @@ router.patch('/v1/save-goals/:id/decrease-balance',
             const result = validationResult(req);
             if (result.isEmpty()) {
                 const data: RequestDecreaseSaveGoal = matchedData(req);
-                data.id = req.params.id;
+                data.id = req.params.id as string;
                 await container.saveGoalUseCase?.decreaseSaveGoal.execute(data);
 
                 res.sendStatus(200);

--- a/apps/agni-server/src/routes/scheduleTransaction.ts
+++ b/apps/agni-server/src/routes/scheduleTransaction.ts
@@ -112,7 +112,7 @@ router.put('/v1/schedule-transactions/:id',
             } 
 
             const data: RequestUpdateScheduleTransaction = matchedData(req);
-            data.id = req.params.id;
+            data.id = req.params.id as string;
             await container.scheduleTransactionUseCase?.updateScheduleTransaction.execute(data);
 
             res.sendStatus(200);

--- a/apps/agni-server/src/routes/tags.ts
+++ b/apps/agni-server/src/routes/tags.ts
@@ -38,7 +38,7 @@ router.put(`/v1/tags/:id`,
             const result = validationResult(req);
             if (result.isEmpty()) {
                 const data: RequestUpdateTagUseCase = matchedData(req);
-                data.id = req.params.id;
+                data.id = req.params.id as string;
                 await container.tagUseCase?.updateTag.execute(data);
 
                 res.sendStatus(200);

--- a/apps/agni-server/src/routes/transactions.ts
+++ b/apps/agni-server/src/routes/transactions.ts
@@ -49,7 +49,7 @@ router.put("/v1/transactions/:id",
             const result = validationResult(req);
             if (result.isEmpty()) {
                 const data: RequestUpdateTransactionUseCase = matchedData(req);
-                data.id = req.params.id;
+                data.id = req.params.id as string;
                 await container.transactionUseCase?.updateTransaction.execute(data);
 
                 res.sendStatus(200);


### PR DESCRIPTION
Updated all route handlers to explicitly cast req.params.id (and similar params) to string before assignment or use. This change improves type safety and prevents potential issues when using TypeScript with Express route parameters.