### PR TITLE
Allow type and categoryId to be optional for freeze transactions

### DIFF
--- a/apps/agni-server/src/core/interactions/scheduleTransaction/createScheduleTransaction.ts
+++ b/apps/agni-server/src/core/interactions/scheduleTransaction/createScheduleTransaction.ts
@@ -27,7 +27,7 @@ export type RequestCreateScheduleTransaction = {
     categoryId?: string
     description: string 
     tagIds: string[]
-    type: string
+    type?: string
     schedule: RequestCreateScheduleTransactionScheduler
 }
 
@@ -51,6 +51,9 @@ export class CreateScheduleTransactionUseCase implements IUsecase<RequestCreateS
 
         if (!request.isFreeze && !request.categoryId)
             throw new ValidationError("CATEGORY_MUST_BE_DEFINE_WHEN_IS_NOT_FREEZE_TRANSACTION")
+
+        if (!request.isFreeze && !request.type)
+            throw new ValidationError("TYPE_TRANSACTION_MUST_BE_DEFINE")
 
         if (!request.isFreeze && !await this.transcationDependencies.categoryRepository?.get(request.categoryId!))
             throw new ResourceNotFoundError("CATEGORY_NOT_FOUND")
@@ -76,7 +79,7 @@ export class CreateScheduleTransactionUseCase implements IUsecase<RequestCreateS
             request.accountId, 
             request.isFreeze ? FREEZE_CATEGORY_ID : request.categoryId!,
             new Money(request.amount),
-            request.isFreeze ? TransactionType.OTHER : mapperMainTransactionCategory(request.type),
+            request.isFreeze ? TransactionType.OTHER : mapperMainTransactionCategory(request.type!),
             scheduler,
             false,
             request.isFreeze,

--- a/apps/agni-server/src/routes/scheduleTransaction.ts
+++ b/apps/agni-server/src/routes/scheduleTransaction.ts
@@ -29,7 +29,7 @@ router.post('/v1/schedule-transactions',
     body('schedule.repeater.interval').notEmpty().isNumeric(),
     body('schedule.dueDate').notEmpty().isISO8601().toDate(),
     body('tagIds').isArray(),
-    body('type').notEmpty(),
+    body('type').optional().isString(),
     async (req, res) => {
         try {
             const result = validationResult(req);

--- a/apps/agni-web/components/Modal/EditScheduleTransaction.vue
+++ b/apps/agni-web/components/Modal/EditScheduleTransaction.vue
@@ -62,10 +62,10 @@ function validate(state: Partial<EditScheduleTransactionType>): FormError[] {
 
   if (!state.name) errors.push({ name: 'name', message: 'Required' })
   if (!state.accountId) errors.push({ name: 'accountId', message: 'Required' })
-  if (!state.categoryId) errors.push({ name: 'categoryId', message: 'Required' })
+  if (!state.isFreeze && !state.categoryId) errors.push({ name: 'categoryId', message: 'Required' })
   if (!state.amount) errors.push({ name: 'amount', message: 'Required' })
   if (!dueDate.value) errors.push({ name: 'dueDate', message: 'Required' })
-  if (!state.type) errors.push({ name: 'type', message: 'Required' })
+  if (!state.isFreeze && !state.type) errors.push({ name: 'type', message: 'Required' })
 
   if (state.repeater && !state.repeater.period) errors.push({ name: 'period', message: 'Required' })
   if (state.repeater && !state.repeater.interval) errors.push({ name: 'interval', message: 'Required' })


### PR DESCRIPTION
Updated backend and frontend validation to require 'type' and 'categoryId' only when the transaction is not a freeze transaction. This change ensures that freeze transactions can be created without specifying these fields, improving flexibility and aligning validation across the API and UI.