### PR TITLE
Add BusinessAccount and invoice pagination

### DIFF
--- a/apps/agni_api/src/main/kotlin/dev/auguste/agni_api/controllers/models/accounts.kt
+++ b/apps/agni_api/src/main/kotlin/dev/auguste/agni_api/controllers/models/accounts.kt
@@ -7,6 +7,7 @@ import dev.auguste.agni_api.core.entities.interfaces.IAccountDetail
 import dev.auguste.agni_api.core.usecases.accounts.dto.CreateAccountInput
 import dev.auguste.agni_api.core.usecases.accounts.dto.UpdateAccountInput
 import dev.auguste.agni_api.core.value_objects.BrokingAccountDetail
+import dev.auguste.agni_api.core.value_objects.BusinessAccountDetail
 import dev.auguste.agni_api.core.value_objects.CheckingAccountDetail
 import dev.auguste.agni_api.core.value_objects.CreditCardAccountDetail
 import dev.auguste.agni_api.core.value_objects.SavingAccountDetail
@@ -70,7 +71,9 @@ fun mapAccountDetail(type: String, model: ApiAccountDetailModel) : IAccountDetai
                 ManagementAccountType.fromString(model.managementAccountType),
                 ContributionAccountType.fromString(model.contributionType) )
         }
-        else -> CheckingAccountDetail(0.0)
+        AccountType.BUSINESS -> {
+            BusinessAccountDetail(0.0)
+        }
     }
 }
 

--- a/apps/agni_api/src/main/kotlin/dev/auguste/agni_api/core/adapters/readers/IInvoicetransactionCountReader.kt
+++ b/apps/agni_api/src/main/kotlin/dev/auguste/agni_api/core/adapters/readers/IInvoicetransactionCountReader.kt
@@ -1,9 +1,12 @@
 package dev.auguste.agni_api.core.adapters.readers
 
+import dev.auguste.agni_api.core.adapters.dto.QueryFilter
 import dev.auguste.agni_api.core.adapters.repositories.IQueryExtend
 import dev.auguste.agni_api.core.entities.Invoice
 import dev.auguste.agni_api.core.entities.Transaction
+import dev.auguste.agni_api.core.usecases.ListOutput
 
 interface IInvoicetransactionCountReader {
     fun count(queryInvoiceExtend: IQueryExtend<Invoice>, queryTransactionExtend: IQueryExtend<Transaction>): Long
+    fun pagination(query: QueryFilter, queryInvoiceExtend: IQueryExtend<Invoice>, queryTransactionExtend: IQueryExtend<Transaction>): ListOutput<Invoice>
 }

--- a/apps/agni_api/src/main/kotlin/dev/auguste/agni_api/core/usecases/budgets/GetAllBudgets.kt
+++ b/apps/agni_api/src/main/kotlin/dev/auguste/agni_api/core/usecases/budgets/GetAllBudgets.kt
@@ -35,7 +35,7 @@ class GetAllBudgets(
                 status = InvoiceStatusType.COMPLETED
             ))
 
-            val currentBalance = resultBalance.balance
+            val currentBalance = resultBalance.spend
             val saveBalance = savingGoals.filter { budget.targetSavingGoalIds.contains(it.id) }.sumOf { it.balance }
 
             result.add(

--- a/apps/agni_api/src/main/kotlin/dev/auguste/agni_api/core/usecases/invoices/GetAllInvoices.kt
+++ b/apps/agni_api/src/main/kotlin/dev/auguste/agni_api/core/usecases/invoices/GetAllInvoices.kt
@@ -32,21 +32,21 @@ class GetAllInvoices(
             mouvementType = input.mouvementType
         )
 
-        val invoices = invoiceRepo.getAll(input.queryFilter, queryInvoiceExtend )
         val queryTransactionExtend = QueryTransactionExtend(
-            invoiceIds = invoices.items.map { it.id }.toSet(),
+            invoiceIds = null,
             categoryIds = input.categoryIds,
             tagIds = input.tagIds,
             budgetIds = input.budgetIds,
             minAmount = input.minAmount,
             maxAmount = input.maxAmount
         )
-        val totalItems = invoiceTransactionCountReader.count(queryInvoiceExtend, queryTransactionExtend)
+
+        val invoices = invoiceTransactionCountReader.pagination(input.queryFilter, queryInvoiceExtend, queryTransactionExtend)
 
         val results = mutableListOf<GetInvoiceOutput>()
 
         val transactions = getInvoiceTransactions.execAsync(GetInvoiceTransactionsInput(
-            invoiceIds = queryTransactionExtend.invoiceIds!!,
+            invoiceIds = invoices.items.map { it.id }.toSet(),
             categoryIds = queryTransactionExtend.categoryIds,
             tagIds = queryTransactionExtend.tagIds,
             budgetIds = queryTransactionExtend.budgetIds,
@@ -78,7 +78,7 @@ class GetAllInvoices(
 
         return ListOutput(
             items = results,
-            total = totalItems
+            total = invoices.total,
         )
     }
 }

--- a/apps/agni_api/src/main/kotlin/dev/auguste/agni_api/core/value_objects/BusinessAccountDetail.kt
+++ b/apps/agni_api/src/main/kotlin/dev/auguste/agni_api/core/value_objects/BusinessAccountDetail.kt
@@ -1,0 +1,30 @@
+package dev.auguste.agni_api.core.value_objects
+
+import dev.auguste.agni_api.core.entities.enums.AccountType
+import dev.auguste.agni_api.core.entities.interfaces.IAccountDetail
+
+data class BusinessAccountDetail(val buffer: Double) : IAccountDetail {
+    override fun getType(): AccountType {
+        return AccountType.BUSINESS
+    }
+
+    override fun toMap(): Map<String, Any> {
+        return mapOf("buffer" to buffer)
+    }
+
+    companion object {
+        fun fromMap(map: Map<String, Any>?): IAccountDetail {
+            if (map == null)
+                return CheckingAccountDetail(buffer = 0.0)
+
+            if (!map.containsKey("buffer"))
+                return CheckingAccountDetail(buffer = 0.0)
+
+            var buffer = map["buffer"]
+            if (buffer is Int)
+                buffer = buffer.toDouble()
+
+            return CheckingAccountDetail(buffer =  buffer as Double)
+        }
+    }
+}

--- a/apps/agni_api/src/main/kotlin/dev/auguste/agni_api/infras/persistences/QueryExtendJdbcAdapter.kt
+++ b/apps/agni_api/src/main/kotlin/dev/auguste/agni_api/infras/persistences/QueryExtendJdbcAdapter.kt
@@ -40,7 +40,7 @@ import kotlin.collections.toSet
 
 // TODO: Refactoring
 
-private fun <M, E>addPaginationSqlStringBuilder(
+internal fun <M, E>addPaginationSqlStringBuilder(
     sql: StringBuilder,
     params: MapSqlParameterSource,
     queryFilter: QueryFilter,
@@ -82,7 +82,7 @@ class QueryInvoiceExtendJdbcAdapter(
 
         if (!extend.types.isNullOrEmpty()) {
             sql.append(" AND LOWER(type) IN (:types)")
-            params.addValue("types", extend.types.map { it.value }.toSet())
+            params.addValue("types", extend.types.map { it.value.lowercase() }.toSet())
         }
 
         extend.status?.let {

--- a/apps/agni_api/src/main/kotlin/dev/auguste/agni_api/infras/persistences/jbdc_model/Account.kt
+++ b/apps/agni_api/src/main/kotlin/dev/auguste/agni_api/infras/persistences/jbdc_model/Account.kt
@@ -7,6 +7,7 @@ import dev.auguste.agni_api.core.entities.Account
 import dev.auguste.agni_api.core.entities.enums.AccountType
 import dev.auguste.agni_api.core.entities.interfaces.IAccountDetail
 import dev.auguste.agni_api.core.value_objects.BrokingAccountDetail
+import dev.auguste.agni_api.core.value_objects.BusinessAccountDetail
 import dev.auguste.agni_api.core.value_objects.CheckingAccountDetail
 import dev.auguste.agni_api.core.value_objects.CreditCardAccountDetail
 import dev.auguste.agni_api.core.value_objects.SavingAccountDetail
@@ -54,7 +55,7 @@ class JdbcAccountModelMapper(
                 AccountType.CREDIT_CARD-> CreditCardAccountDetail.fromMap(detailMap)
                 AccountType.CHECKING -> CheckingAccountDetail.fromMap(detailMap)
                 AccountType.BROKING-> BrokingAccountDetail.fromMap(detailMap)
-                AccountType.BUSINESS -> CheckingAccountDetail(0.0)
+                AccountType.BUSINESS -> BusinessAccountDetail(0.0)
             }
         }
 

--- a/apps/agni_api/src/main/resources/application.properties
+++ b/apps/agni_api/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.datasource.url=${DB_URL:jdbc:postgresql://localhost:5432/test2}
+spring.datasource.url=${DB_URL:jdbc:postgresql://localhost:5432/tests}
 spring.datasource.username=${DB_USERNAME:postgres}
 spring.datasource.password=${DB_PASSWORD:root}
 spring.datasource.driver-class-name=org.postgresql.Driver


### PR DESCRIPTION
Introduce BusinessAccountDetail value object and wire it into account mapping (controller and JDBC model). Add pagination support to IInvoicetransactionCountReader and implement it in JdbcInvoiceTransactionCountReader (refactor buildStringSql, use mapper, return ListOutput with items and total). Adjust QueryExtendJdbcAdapter visibility for addPaginationSqlStringBuilder and normalize type values to lowercase. Update GetAllInvoices to use the new pagination path and fix GetAllBudgets to use resultBalance.spend. Also update default datasource URL in application.properties.