### PR TITLE
Update fund deletion flow and saving goal models

### DIFF
--- a/apps/agni-web/composables/api/funds.ts
+++ b/apps/agni-web/composables/api/funds.ts
@@ -14,8 +14,8 @@ export async function useCreateFund(request: CreateFundRequest): Promise<Created
 
 
 export async function useDeleteFund(saveGoalId: string, request: DeleteFundRequest): Promise<void> {
-    await $fetch(`api/funds/${saveGoalId}`, {
-        method: 'DELETE',
+    await $fetch(`api/funds/${saveGoalId}/remove`, {
+        method: 'PUT',
         body: request
     });
 }

--- a/apps/agni-web/pages/funds/index.vue
+++ b/apps/agni-web/pages/funds/index.vue
@@ -17,6 +17,7 @@ import type { EditFundType, EditUpdateAmountFundType, FundType } from "~/types/u
 
 interface ItemRow  {
     id: string
+    accountId?: string
     title: string
     description: string
     target: number 
@@ -56,7 +57,9 @@ const { data: goals, error, refresh } = useAsyncData('goal+page', async () => {
 })  
 
 const { data: summary } = useAsyncData('page-fund-summary', async () => {
+    loadingSummary.value = true
     const res = await fetchFundSummary()
+    loadingSummary.value = false
 
     return {
         totalTarget: res.totalTarget,
@@ -74,6 +77,7 @@ const tableData = computed(() => {
         title: i.title,
         balance: i.balance,
         description: i.description,
+        accountId: i.accountId,
         target: i.target,
     } satisfies ItemRow))
 })
@@ -189,28 +193,20 @@ const deletePopOverOpen = ref(false)
 const deletePopOverGoalId = ref<string>()
 
 const onDeleteGoal = async (goalId: string) => {
-    if (deleteAccountDepositId.value !== '') {
-        try {
-            await useDeleteFund(goalId, { accountId: deleteAccountDepositId.value })
-            await refresh()
-            deletePopOverOpen.value = false
-            deletePopOverGoalId.value = undefined
-            toast.add({
-                title: 'Succès',
-                description: 'Objectif supprimé',
-                color: 'success'
-            })
-        } catch(err) {
-            toast.add({
-                title: 'Erreur',
-                description: 'Impossible de supprimer l\'objectif',
-                color: 'error'
-            })
-        }
-    } else {
+    try {
+        await useDeleteFund(goalId, { accountId: deleteAccountDepositId.value })
+        await refresh()
+        deletePopOverOpen.value = false
+        deletePopOverGoalId.value = undefined
+        toast.add({
+            title: 'Succès',
+            description: 'Fund supprimé',
+            color: 'success'
+        })
+    } catch(err) {
         toast.add({
             title: 'Erreur',
-            description: 'Veuillez sélectionner un compte de dépôt',
+            description: 'Impossible de supprimer l\'objectif',
             color: 'error'
         })
     }
@@ -338,6 +334,7 @@ const columns: TableColumn<ItemRow>[] = [
                     onClick: () => {
                         deletePopOverOpen.value = true
                         deletePopOverGoalId.value = row.original.id
+                        deleteAccountDepositId.value = row.original.accountId || ''
                     }
                 }),
             ])

--- a/apps/agni-web/types/api/fund.d.ts
+++ b/apps/agni-web/types/api/fund.d.ts
@@ -29,7 +29,7 @@ export type UpgradeFundRequest = {
 }
 
 export type DeleteFundRequest = {
-    accountId: string
+    accountId?: string
 }
 
 export type QueryFilterFundRequest = QueryFilterRequest & {

--- a/apps/agni_api/src/main/kotlin/dev/auguste/agni_api/controllers/models/saving_goals.kt
+++ b/apps/agni_api/src/main/kotlin/dev/auguste/agni_api/controllers/models/saving_goals.kt
@@ -5,11 +5,6 @@ import dev.auguste.agni_api.core.usecases.saving_goals.dto.UpdateSavingGoalInput
 import java.time.LocalDate
 import java.util.UUID
 
-data class ApiItemSavingGoalModel(
-    val title: String,
-    val price: Double,
-    val url: String
-)
 
 data class ApiUpgradeSavingGoalModel(
     val accountId: UUID?,
@@ -20,11 +15,7 @@ data class ApiCreateSavingGoalModel(
     val title: String,
     val target: Double,
     val description: String,
-    val accountId: UUID?,
-    val desirValue: Int,
-    val importance: Int,
-    val wishDueDate: LocalDate?,
-    val items: Set<ApiItemSavingGoalModel>
+    val accountId: UUID?
 )
 
 data class ApiUpdateSavingGoalModel(
@@ -32,10 +23,6 @@ data class ApiUpdateSavingGoalModel(
     val target: Double?,
     val description: String?,
     val accountId: UUID?,
-    val desirValue: Int?,
-    val importance: Int?,
-    val wishDueDate: LocalDate?,
-    val items: Set<ApiItemSavingGoalModel>?
 )
 
 data class ApiDeleteSavingGoalModel(

--- a/apps/agni_api/src/main/kotlin/dev/auguste/agni_api/core/usecases/saving_goals/UpdateSavingGoal.kt
+++ b/apps/agni_api/src/main/kotlin/dev/auguste/agni_api/core/usecases/saving_goals/UpdateSavingGoal.kt
@@ -31,6 +31,12 @@ class UpdateSavingGoal(
             savingGoal.accountId = input.accountId
         }
 
+        if (input.description != null) {
+            if (input.description != savingGoal.description) {
+                savingGoal.description = input.description
+            }
+        }
+
         if (savingGoal.hasChanged())
             savingGoalRepo.update(savingGoal)
     }


### PR DESCRIPTION
Frontend: change useDeleteFund to call PUT api/funds/{id}/remove, make DeleteFundRequest.accountId optional, include accountId in table rows, preselect accountId when opening delete popover, simplify deletion flow and adjust toast texts, and toggle loadingSummary when fetching summary. Backend: simplify saving goal API models (remove items/desirValue/importance/wishDueDate from create/update models) and make delete/create payloads slimmer. Usecase: UpdateSavingGoal now only updates description when a non-null different value is provided. Files touched: apps/agni-web/composables/api/funds.ts, apps/agni-web/pages/funds/index.vue, apps/agni-web/types/api/fund.d.ts, apps/agni_api/controllers/models/saving_goals.kt, apps/agni_api/core/usecases/saving_goals/UpdateSavingGoal.kt